### PR TITLE
One-click accessible option to switch language from the home page

### DIFF
--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -124,6 +124,12 @@ object layout {
       )
     )
 
+  private def switchLanguage(implicit ctx: Context) =
+    spaceless(s"""<form method="post" action="/translation/select" class="header-langs">
+    ${ if (ctx.lang.language == "en") """<button type="submit" name="lang" value="ja-JP" title="ja-JP">日本語</button>""" else "" }
+    ${ if (ctx.lang.language == "ja") """<button type="submit" name="lang" value="en-US" title="en-US">English</button>""" else "" }
+    </form>""")
+
   private lazy val botImage = img(
     src := staticUrl("images/icons/bot.png"),
     title := "Robot chess",
@@ -309,6 +315,7 @@ object layout {
           topnav()
         ),
         div(cls := "site-buttons")(
+          if (ctx.req.path == "/") switchLanguage else "",
           clinput,
           reports,
           teamRequests,

--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -126,8 +126,8 @@ object layout {
 
   private def switchLanguage(implicit ctx: Context) =
     spaceless(s"""<form method="post" action="/translation/select" class="header-langs">
-    ${ if (ctx.lang.language == "en") """<button type="submit" name="lang" value="ja-JP" title="ja-JP">日本語</button>""" else "" }
-    ${ if (ctx.lang.language == "ja") """<button type="submit" name="lang" value="en-US" title="en-US">English</button>""" else "" }
+    ${ if (ctx.lang.language == "en") """<button type="submit" name="lang" value="ja-JP" title="ja-JP">日本語</button>"""
+        else """<button type="submit" name="lang" value="en-US" title="en-US">English</button>""" }
     </form>""")
 
   private lazy val botImage = img(

--- a/ui/common/css/header/_buttons.scss
+++ b/ui/common/css/header/_buttons.scss
@@ -7,6 +7,14 @@
 .site-buttons {
   @extend %flex-center-nowrap;
 
+  .header-langs {
+    button {
+      padding: 0 .3rem;
+      border: none;
+      background: none;
+    }
+  }
+
   .link {
     @extend %top-icon;
     /* we don't want a lighter dark font in the top gradient */


### PR DESCRIPTION
Added "日本語" button for switching language. It changes to "English" when already in Japanese.
It is only visible in the home page '/'