### PR TITLE
Speech synthesis no longer reads "undefined"

### DIFF
--- a/ui/@types/lishogi/index.d.ts
+++ b/ui/@types/lishogi/index.d.ts
@@ -92,7 +92,7 @@ interface Lishogi {
 
 interface LishogiSpeech {
   say(t: string, cut: boolean): void;
-  step(s: { san?: San }, cut: boolean): void;
+  step(s: { san?: San, uci?: Uci }, cut: boolean): void;
 }
 
 interface PalantirOpts {

--- a/ui/common/src/notation.ts
+++ b/ui/common/src/notation.ts
@@ -128,7 +128,6 @@ function westernShogiNotation(move: ExtendedMoveInfo): string {
 }
 
 function westernShogiNotation2(move: ExtendedMoveInfo): string {
-
     const parsed = parseMove(move.san, move.uci);
     const piece = WESTERN_ROLE_SYMBOLS[parsed.role];
     const origin = sanContainsOrigin(move.san) ? (`${makeSquare(parsed.orig)}`) : "";

--- a/ui/speech/src/main.ts
+++ b/ui/speech/src/main.ts
@@ -1,4 +1,5 @@
 import { notationStyle } from 'common/notation';
+import { Notation } from 'common/notation';
 
 const roles: { [letter: string]: string } = {
   B: "bishop",
@@ -14,8 +15,8 @@ const roles: { [letter: string]: string } = {
   T: "tokin",
 };
 
-function renderSan(san: San) {
-  let move = notationStyle(0)({san: san, uci: '', fen: ''}); // todo
+function renderSan(san: San, uci: Uci) {
+  let move = notationStyle(Notation.WesternEngine)({san: san, uci: uci, fen: ''});
   if(move[0] === "+") move = "$" + move.substring(1);
   return move
       .split("")
@@ -47,6 +48,6 @@ export function say(text: string, cut: boolean) {
   window.lishogi.sound.say(msg);
 }
 
-export function step(s: { san?: San }, cut: boolean) {
-  say(s.san ? renderSan(s.san) : "Game start", cut);
+export function step(s: { san?: San, uci?: Uci }, cut: boolean) {
+  say(s.san ? renderSan(s.san, s.uci || "") : "Game start", cut);
 }


### PR DESCRIPTION
Instead, reads in "Western Engine" notation (e.g. "Pawn 2 f"). Previously, the destination square inside the `speech` code was `undefined`, so the voice reads out `Pawn u n d e f i n e d u n d e f i n e d` (you can test this on prod Lishogi).

This change changes the speech interface at `step` to accept both a `san` and `uci`. From looking at the code, it seems like everywhere the `step(...)` function inside `speech.ts` is called, it's called with a `uci` (via a `step` or `TreeNode` object).

This is necessary because in order to construct the correct format of the destination square, the `Notation` code requires both a `san` and a `uci`, as opposed to parsing it out of the `Ph4` chess-style variant.

Once it could get the correct format, the code already seems to work fine. I've played around with the analysis board on my local lishogi instance to confirm that this works. Note I haven't tested this exhaustively, such as in-game situations.

Future work here might be to try and take into account the user's notation preference in TTS - however, the TTS engine was unable to read Japanese notation when I tried it, so there's probably a LOT more work there...