### PR TITLE
Add license info for western piece set

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -63,6 +63,7 @@ public/piece/tatiana | [sadsnake1](https://github.com/sadsnake1) | [CC BY-NC-SA 
 public/piece/staunty | [sadsnake1](https://github.com/sadsnake1) | [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 public/piece/dubrovny | [sadsnake1](https://github.com/sadsnake1) | [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 public/piece/libra | [sadsnake1](https://github.com/sadsnake1) | [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)
+public/piece/western | [peanatsu](https://github.com/peanatsu) | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)
 public/sounds/futuristic | [Enigmahack](https://github.com/Enigmahack) | AGPLv3+
 public/sounds/nes | [Enigmahack](https://github.com/Enigmahack) | AGPLv3+
 public/sounds/piano | [Enigmahack](https://github.com/Enigmahack) | AGPLv3+


### PR DESCRIPTION
hi,

I added the license info for the western piece set in the "Exceptions (free)" table of the COPYING.md file right after the other piece sets, which btw all seem to be lichess sets. I wonder if we have to keep the lichess-set licenses in the file (after all the files still exist in the commit history, but then so do their licenses). I wasnt sure so I deleted nothing and just added mine.