### PR TITLE
change kifu extension from .kifu to .kif

### DIFF
--- a/app/views/analyse/replay.scala
+++ b/app/views/analyse/replay.scala
@@ -58,7 +58,7 @@ object replay {
         href := s"data:text/plain;charset=utf-8,${UriEncoding.encodePathSegment(kifu, "UTF-8")}",
         attr(
           "download"
-        ) := s"${game.createdAt}-${game.sentePlayer.userId | "Anonymous"}-vs-${game.gotePlayer.userId | "Anonymous"}.kifu"
+        ) := s"${game.createdAt}-${game.sentePlayer.userId | "Anonymous"}-vs-${game.gotePlayer.userId | "Anonymous"}.kif"
       )(
         trans.downloadRaw()
       ),


### PR DESCRIPTION
Not sure what the standard is, but I have never seen .kifu files in the wild, only .kif files, and shogidokoro simply wont open .kifu files, so my guess is that .kif is the better choice. (shogidokoro *will* open kifu files from lishogi once you rename them to .kif, so it's only a cosmetic issue)

Also note that I only changed one line in one file. I didnt see ".kifu" mentioned anywhere else in the source. I tested locally and game export to .kif worked for a game between two anonymous users.