### PR TITLE
Change Elite Arena to Weekend Arena

### DIFF
--- a/app/views/tournament/leaderboard.scala
+++ b/app/views/tournament/leaderboard.scala
@@ -48,7 +48,7 @@ object leaderboard {
     ) {
       def eliteWinners =
         section(
-          h2(cls := "text", dataIcon := "C")("Elite Arena"),
+          h2(cls := "text", dataIcon := "C")("Weekend Arena"),
           ul(
             winners.elite.map { w =>
               li(


### PR DESCRIPTION
What used to be called Elite Arena is now called Weekend Arena