### PR TITLE
Tournament fixes

### DIFF
--- a/modules/tournament/src/main/TournamentShield.scala
+++ b/modules/tournament/src/main/TournamentShield.scala
@@ -169,9 +169,9 @@ object TournamentShield {
       SuperBlitz,
       Blitz,
       Rapid,
-      Classical,
-      HyperBullet,
-      UltraBullet
+      Classical
+      //HyperBullet,
+      //UltraBullet
     )
 
     def of(t: Tournament): Option[Category] = all.find(_ matches t)


### PR DESCRIPTION
A Bullet Arena was named 'SuperBlitz' so I have renamed it to 'Bullet Arena', and further the Bullet Arena has been named 'SuperBullet' Arena.

Further this page https://lishogi.org/tournament/leaderboard had HyperBullet leaderboard, but lishogi doesn't schedule any HyperBullet Arenas, so I have removed that and added Classical instead.