### PR TITLE
Fix tournaments leaderboard

### DIFF
--- a/app/views/tournament/leaderboard.scala
+++ b/app/views/tournament/leaderboard.scala
@@ -79,12 +79,13 @@ object leaderboard {
           h1("Tournament winners"),
           div(cls := "tournament-leaderboards")(
             eliteWinners,
-            freqWinners(winners.hyperbullet, PerfType.Bullet, "HyperBullet"),
+            //freqWinners(winners.hyperbullet, PerfType.Bullet, "HyperBullet"),
             freqWinners(winners.bullet, PerfType.Bullet, "Bullet"),
             freqWinners(winners.superblitz, PerfType.Blitz, "SuperBlitz"),
             freqWinners(winners.blitz, PerfType.Blitz, "Blitz"),
             freqWinners(winners.hyperrapid, PerfType.Rapid, "HyperRapid"),
             freqWinners(winners.rapid, PerfType.Rapid, "Rapid"),
+            freqWinners(winners.classical, PerfType.Classical, "Classical"),
             marathonWinners,
             lila.tournament.WinnersApi.variants.map { v =>
               PerfType.byVariant(v).map { pt =>

--- a/modules/tournament/src/main/TournamentShield.scala
+++ b/modules/tournament/src/main/TournamentShield.scala
@@ -122,17 +122,17 @@ object TournamentShield {
 
   object Category {
 
-    case object UltraBullet
-        extends Category(
-          of = Left(Schedule.Speed.UltraBullet),
-          iconChar = '{'
-        )
+    //case object UltraBullet
+    //    extends Category(
+    //      of = Left(Schedule.Speed.UltraBullet),
+    //      iconChar = '{'
+    //    )
 
-    case object HyperBullet
-        extends Category(
-          of = Left(Schedule.Speed.HyperBullet),
-          iconChar = 'T'
-        )
+    //case object HyperBullet
+    //    extends Category(
+    //      of = Left(Schedule.Speed.HyperBullet),
+    //      iconChar = 'T'
+    //    )
 
     case object Bullet
         extends Category(
@@ -169,9 +169,9 @@ object TournamentShield {
       SuperBlitz,
       Blitz,
       Rapid,
-      Classical,
-      HyperBullet,
-      UltraBullet
+      Classical
+      //HyperBullet,
+      //UltraBullet
     )
 
     def of(t: Tournament): Option[Category] = all.find(_ matches t)

--- a/modules/tournament/src/main/WinnersApi.scala
+++ b/modules/tournament/src/main/WinnersApi.scala
@@ -32,19 +32,20 @@ case class FreqWinners(
 }
 
 case class AllWinners(
-    hyperbullet: FreqWinners,
+    //hyperbullet: FreqWinners,
     bullet: FreqWinners,
     superblitz: FreqWinners,
     blitz: FreqWinners,
     hyperrapid: FreqWinners,
     rapid: FreqWinners,
+    classical: FreqWinners,
     elite: List[Winner],
     marathon: List[Winner],
     variants: Map[String, FreqWinners]
 ) {
 
   lazy val top: List[Winner] = List(
-    List(hyperbullet, bullet, superblitz, blitz, hyperrapid, rapid).flatMap(_.top),
+    List(bullet, superblitz, blitz, hyperrapid, rapid, classical).flatMap(_.top),
     List(elite.headOption, marathon.headOption).flatten,
     WinnersApi.variants.flatMap { v =>
       variants get v.key flatMap (_.top)
@@ -52,7 +53,7 @@ case class AllWinners(
   ).flatten
 
   def userIds =
-    List(hyperbullet, bullet, superblitz, blitz, hyperrapid, rapid).flatMap(_.userIds) :::
+    List(bullet, superblitz, blitz, hyperrapid, rapid, classical).flatMap(_.userIds) :::
       elite.map(_.userId) ::: marathon.map(_.userId) :::
       variants.values.toList.flatMap(_.userIds)
 }
@@ -108,12 +109,13 @@ final class WinnersApi(
           daily = firstStandardWinner(dailies, speed)
         )
       AllWinners(
-        hyperbullet = standardFreqWinners(Speed.HyperBullet),
+        //hyperbullet = standardFreqWinners(Speed.HyperBullet),
         bullet = standardFreqWinners(Speed.Bullet),
         superblitz = standardFreqWinners(Speed.SuperBlitz),
         blitz = standardFreqWinners(Speed.Blitz),
         hyperrapid = standardFreqWinners(Speed.HyperRapid),
         rapid = standardFreqWinners(Speed.Rapid),
+        classical = standardFreqWinners(Speed.Classical),
         elite = elites flatMap (_.winner) take 4,
         marathon = marathons flatMap (_.winner) take 4,
         variants = WinnersApi.variants.view.map { v =>


### PR DESCRIPTION
https://lishogi.org/tournament/leaderboard Has a hyperbullet arena and lishogi doesn't conduct hyperbullet arena, so I've replaced that with the classical arena.

lishogi doesn't conduct hyperbullet and ultrabullet shields, but they are here https://lishogi.org/tournament/shields so I have removed that too.