### PR TITLE
Fix challenge clock validation

### DIFF
--- a/modules/setup/src/main/ApiAiConfig.scala
+++ b/modules/setup/src/main/ApiAiConfig.scala
@@ -78,7 +78,7 @@ object ApiAiConfig extends BaseConfig {
   ) =
     new ApiAiConfig(
       variant = shogi.variant.Variant.orDefault(~v),
-      clock = cl.filter(c => c.limitSeconds > 0 || c.hasIncrement),
+      clock = cl.filter(c => c.limitSeconds > 0 || c.hasIncrement || c.hasByoyomi),
       daysO = d,
       color = Color.orDefault(~c),
       level = l,

--- a/modules/setup/src/main/ApiAiConfig.scala
+++ b/modules/setup/src/main/ApiAiConfig.scala
@@ -78,7 +78,7 @@ object ApiAiConfig extends BaseConfig {
   ) =
     new ApiAiConfig(
       variant = shogi.variant.Variant.orDefault(~v),
-      clock = cl,
+      clock = cl.filter(c => c.limitSeconds > 0 || c.hasIncrement),
       daysO = d,
       color = Color.orDefault(~c),
       level = l,

--- a/modules/setup/src/main/ApiConfig.scala
+++ b/modules/setup/src/main/ApiConfig.scala
@@ -52,7 +52,7 @@ object ApiConfig extends BaseHumanConfig {
   ) =
     new ApiConfig(
       variant = shogi.variant.Variant.orDefault(~v),
-      clock = cl.filter(c => c.limitSeconds > 0 || c.hasIncrement),
+      clock = cl.filter(c => c.limitSeconds > 0 || c.hasIncrement || c.hasByoyomi),
       days = d,
       rated = r,
       color = Color.orDefault(~c),

--- a/modules/setup/src/main/ApiConfig.scala
+++ b/modules/setup/src/main/ApiConfig.scala
@@ -52,7 +52,7 @@ object ApiConfig extends BaseHumanConfig {
   ) =
     new ApiConfig(
       variant = shogi.variant.Variant.orDefault(~v),
-      clock = cl,
+      clock = cl.filter(c => c.limitSeconds > 0 || c.hasIncrement),
       days = d,
       rated = r,
       color = Color.orDefault(~c),

--- a/modules/setup/src/main/OpenConfig.scala
+++ b/modules/setup/src/main/OpenConfig.scala
@@ -35,7 +35,7 @@ object OpenConfig {
   def from(v: Option[String], cl: Option[Clock.Config], pos: Option[String]) =
     new OpenConfig(
       variant = shogi.variant.Variant.orDefault(~v),
-      clock = cl,
+      clock = cl.filter(c => c.limitSeconds > 0 || c.hasIncrement),
       position = pos map FEN
     ).autoVariant
 }

--- a/modules/setup/src/main/OpenConfig.scala
+++ b/modules/setup/src/main/OpenConfig.scala
@@ -35,7 +35,7 @@ object OpenConfig {
   def from(v: Option[String], cl: Option[Clock.Config], pos: Option[String]) =
     new OpenConfig(
       variant = shogi.variant.Variant.orDefault(~v),
-      clock = cl.filter(c => c.limitSeconds > 0 || c.hasIncrement),
+      clock = cl.filter(c => c.limitSeconds > 0 || c.hasIncrement || c.hasByoyomi),
       position = pos map FEN
     ).autoVariant
 }


### PR DESCRIPTION
Prevents users from creating 0+0|0 challenges.

Prevents creating the following challenges with API:
- Open ended challenges
- Challenging another user with the API
- Challenging the AI with the API

https://github.com/RoepStoep/lidraughts/commit/758f33ba1714aa0c5f92cf94d96b5923771750bb