### PR TITLE
Fix #220 (name tags in ongoing game)

### DIFF
--- a/ui/analyse/src/clocks.ts
+++ b/ui/analyse/src/clocks.ts
@@ -5,7 +5,7 @@ import { isFinished } from './study/studyChapters';
 import * as game from 'game';
 
 export default function renderClocks(ctrl: AnalyseCtrl): [VNode, VNode] | undefined {
-  if (ctrl.embed || ctrl.data.game.id === 'synthetic' || ctrl.data.forecast) return;
+  if (ctrl.embed || ctrl.data.game.id === 'synthetic' || ctrl.data.game.status.name === 'started') return;
   const node = ctrl.node,
     clock = node.clock,
     sentePov = ctrl.bottomIsSente(),


### PR DESCRIPTION
Already tested in other analysis pages, like "Analysis board" where the nametags/clocks actually show up. This shouldn't affect anything else...
`ctrl.data.game.status.name === 'started'` means the clock gets hidden if game is started but not finished. If the game was already finished this value would be different from 'started', like 'resign' or 'abort'.