### PR TITLE
Add simul schedule to API output

### DIFF
--- a/modules/simul/src/main/JsonView.scala
+++ b/modules/simul/src/main/JsonView.scala
@@ -44,10 +44,14 @@ final class JsonView(
 
   def api(simul: Simul): Fu[JsObject] =
     getLightUser(simul.hostId) map { lightHost =>
-      baseSimul(simul, lightHost) ++ Json.obj(
-        "nbApplicants" -> simul.applicants.size,
-        "nbPairings"   -> simul.pairings.size
-      )
+      baseSimul(simul, lightHost) ++ Json
+        .obj(
+          "nbApplicants" -> simul.applicants.size,
+          "nbPairings"   -> simul.pairings.size
+        )
+        .add("estimatedStartAt" -> simul.startedAt)
+        .add("startedAt" -> simul.startedAt)
+        .add("finishedAt" -> simul.finishedAt)
     }
 
   def api(simuls: List[Simul]): Fu[JsArray] =


### PR DESCRIPTION
If players schedule multiple simuls, date/time values can be used to discern which simul is which and what date/time each simul was played.