### PR TITLE
Speech - do not pronounce comma

### DIFF
--- a/ui/speech/src/main.ts
+++ b/ui/speech/src/main.ts
@@ -89,6 +89,8 @@ function pronounce(str: string): string | undefined {
       return 'unpromotes';
     case '!':
       return 'promoted';
+    default:
+      return;
   }
 }
 

--- a/ui/speech/src/main.ts
+++ b/ui/speech/src/main.ts
@@ -73,10 +73,11 @@ function toNumber(digit: string): string | undefined {
 
 function pronounce(str: string): string | undefined {
   switch (str) {
+    case ',':
     case '-':
     case '(':
     case ')':
-      return '';
+      return ' ';
     case '*':
       return 'drop';
     case 'x':
@@ -88,8 +89,6 @@ function pronounce(str: string): string | undefined {
       return 'unpromotes';
     case '!':
       return 'promoted';
-    default:
-      return;
   }
 }
 


### PR DESCRIPTION
Not yet tested.  What I want is that 34 should be read as "three four" rather than "three comma four".