### PR TITLE
Fix displayed inverted color of reviewXMistakes

### DIFF
--- a/ui/analyse/src/retrospect/retroView.ts
+++ b/ui/analyse/src/retrospect/retroView.ts
@@ -6,6 +6,7 @@ import { VNode, h } from 'snabbdom';
 import AnalyseCtrl from '../ctrl';
 import { renderIndexAndMove } from '../moveView';
 import { RetroCtrl } from './retroCtrl';
+import { opposite } from 'shogiops/util';
 
 function skipOrViewSolution(ctrl: RetroCtrl) {
   return h('div.choices', [
@@ -217,7 +218,7 @@ const feedback = {
               {
                 hook: bind('click', ctrl.flip),
               },
-              transWithColorName(ctrl.trans, 'reviewXMistakes', ctrl.color, handicap)
+              transWithColorName(ctrl.trans, 'reviewXMistakes', opposite(ctrl.color), handicap)
             ),
           ]),
         ]),


### PR DESCRIPTION
I've found this problem when learning from analyzed games.
It links to the analyzed results of the opponent. But shown with current player.

Before

<img width="226" alt="スクリーンショット 2023-06-09 154502" src="https://github.com/WandererXII/lishogi/assets/1180335/b7b165c7-656a-4cc6-9882-53961cdea3ee">

After

<img width="228" alt="スクリーンショット 2023-06-09 155603" src="https://github.com/WandererXII/lishogi/assets/1180335/11b7487b-ca3e-458a-ae27-5b68de60dc0d">
