### PR TITLE
Revert "handle empty translation text in bin/trans-lint fixes `AttributeError: 'NoneType' object has no attribute 'replace'`"

### DIFF
--- a/bin/trans-lint.py
+++ b/bin/trans-lint.py
@@ -49,7 +49,7 @@ class ReportContext:
         self.path = path
         self.el = el
         self.name = name
-        self.text = text if text else ""
+        self.text = text
 
     def lang(self):
         return self.path.stem
@@ -80,9 +80,6 @@ def lint(report, path):
     for el in root:
         name = el.attrib["name"]
         ctx = ReportContext(report, path, el, name, el.text)
-        if not el.text:
-            ctx.error("missing text")
-            continue
         if "'" in name or " " in name:
             ctx.error(f"bad {el.tag} name")
             continue


### PR DESCRIPTION
Reverts WandererXII/lishogi#760
I think I was wrong, if you think it's right then just close this PR @WandererXII 