### PR TITLE
Make human and bot maximum ply match

### DIFF
--- a/modules/game/src/main/Game.scala
+++ b/modules/game/src/main/Game.scala
@@ -681,8 +681,6 @@ object Game {
     if (variant.chushogi) 1000
     else 700 // unlimited can cause StackOverflowError
 
-  val maxBotPlies = 600
-
   val analysableVariants: Set[Variant] = Set(
     shogi.variant.Standard,
     shogi.variant.Minishogi,

--- a/modules/round/src/main/Player.scala
+++ b/modules/round/src/main/Player.scala
@@ -50,7 +50,7 @@ final private class Player(
 
   private[round] def bot(usi: Usi, round: RoundDuct)(pov: Pov)(implicit proxy: GameProxy): Fu[Events] =
     pov match {
-      case Pov(game, _) if game.playedPlies > Game.maxBotPlies =>
+      case Pov(game, _) if game.playedPlies > Game.maxPlies(game.variant) =>
         round ! TooManyPlies
         fuccess(Nil)
       case Pov(game, color) if game playableBy color =>


### PR DESCRIPTION
Currently, bots have a stricter limit to the maximum plies per game compared to humans. This leads to situations where games will unexpectedly become a draw, despite not being near the 1000 move limit for chushogi (or the 700 move limit for other variants): 

* https://lishogi.org/NnnGKrjM#602
* https://lishogi.org/Q0WDZEfv#602

It looks like when per-variant move limits were added, bots were given their own limit of 600 moves (which appears to be what games used to be limited to a couple years ago according to https://github.com/WandererXII/lishogi/issues/472#issuecomment-1239640750): 

https://github.com/WandererXII/lishogi/blob/65b534483d2e83346ff91131e105f0623ac932d1/modules/game/src/main/Game.scala#L680-L684

This pull request would allow bots to have the exact same move limit as humans for each variant. Feel free to disregard it if there's a reason you feel bots should have a stricter limit, though if that's the case I think it would be helpful to notify bot developers of this difference. Please let me know if there's anything you'd like changed :)