### PR TITLE
Fix lishogi-bot link typo

### DIFF
--- a/public/doc/lishogi-api.yaml
+++ b/public/doc/lishogi-api.yaml
@@ -95,7 +95,7 @@ tags:
   \n### Restrictions\n\
   \ - Bots can only play challenge games: tournaments are off-limits\n\
   \n### Integrations\n\
-  \ - [Python3 lishogi-bot](https://github.com/ThrYoBots/Lishogi-Bot) (official)\n\
+  \ - [Python3 lishogi-bot](https://github.com/TheYoBots/Lishogi-Bot) (official)\n\
   \ - Yours? Please make [an issue or pull request](https://github.com/lishogi-org/api).\n\
   \n### Links\n\
   \ - Join the [Lishogi Bots team](https://lishogi.org/team/lishogi-bots) with your bot account\n\


### PR DESCRIPTION
The link to [Lishogi-Bot](https://github.com/TheYoBots/Lishogi-Bot) has a typo at https://lishogi.org/api#tag/Bot that results in the user being redirected to a 404. This pull request updates the link to be the correct user/repo. 