### PR TITLE
Add Blank and Invisible pieces to Lishogi

### DIFF
--- a/public/piece/Hidden/0_Black.svg
+++ b/public/piece/Hidden/0_Black.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="30mm"
+   height="34mm"
+   viewBox="0 0 30 34"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1374-3-6">
+      <path
+         d="M 0,2834.646 H 2834.646 V 0 H 0 Z"
+         transform="translate(-461.11531,-1475.1781)"
+         id="path1374-2-9" />
+    </clipPath>
+  </defs>
+  <g
+     id="layer1"
+     transform="translate(-164)">
+    <path
+       id="path5326"
+       d="m 0,0 -21.223,7.255 c -0.337,0.115 -0.707,0.115 -1.044,0 L -43.49,0 c -0.512,-0.175 -0.879,-0.592 -0.956,-1.088 L -54.328,-64.8 c -0.128,-0.823 0.569,-1.559 1.477,-1.559 h 31.106 31.106 c 0.907,0 1.605,0.736 1.477,1.559 L 0.955,-1.088 C 0.879,-0.592 0.512,-0.175 0,0"
+       style="font-variation-settings:normal;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.83465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       transform="matrix(0.35277776,0,0,-0.35277776,186.67115,6.5899251)"
+       clip-path="url(#clipPath1374-3-6)" />
+  </g>
+</svg>

--- a/public/piece/Hidden/0_Blank.svg
+++ b/public/piece/Hidden/0_Blank.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="30mm"
+   height="34mm"
+   viewBox="0 0 30 34"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1374-3-9">
+      <path
+         d="M 0,2834.646 H 2834.646 V 0 H 0 Z"
+         transform="translate(-461.11531,-1475.1781)"
+         id="path1374-2-4" />
+    </clipPath>
+  </defs>
+  <g
+     id="layer1"
+     transform="translate(-244)">
+    <path
+       id="path1373-0"
+       d="m 0,0 -21.223,7.255 c -0.337,0.115 -0.707,0.115 -1.044,0 L -43.49,0 c -0.512,-0.175 -0.879,-0.592 -0.956,-1.088 L -54.328,-64.8 c -0.128,-0.823 0.569,-1.559 1.477,-1.559 h 31.106 31.106 c 0.907,0 1.605,0.736 1.477,1.559 L 0.955,-1.088 C 0.879,-0.592 0.512,-0.175 0,0"
+       style="font-variation-settings:normal;fill:#ffc873;fill-opacity:1;fill-rule:nonzero;stroke:#4d3d23;stroke-width:2.83465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       transform="matrix(0.35277776,0,0,-0.35277776,266.67115,6.5899251)"
+       clip-path="url(#clipPath1374-3-9)" />
+  </g>
+</svg>

--- a/public/piece/Hidden/0_White.svg
+++ b/public/piece/Hidden/0_White.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="30mm"
+   height="34mm"
+   viewBox="0 0 30 34"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1374-3">
+      <path
+         d="M 0,2834.646 H 2834.646 V 0 H 0 Z"
+         transform="translate(-461.11531,-1475.1781)"
+         id="path1374-2" />
+    </clipPath>
+  </defs>
+  <g
+     id="layer1"
+     transform="translate(-84)">
+    <path
+       id="path5325"
+       d="m 0,0 -21.223,7.255 c -0.337,0.115 -0.707,0.115 -1.044,0 L -43.49,0 c -0.512,-0.175 -0.879,-0.592 -0.956,-1.088 L -54.328,-64.8 c -0.128,-0.823 0.569,-1.559 1.477,-1.559 h 31.106 31.106 c 0.907,0 1.605,0.736 1.477,1.559 L 0.955,-1.088 C 0.879,-0.592 0.512,-0.175 0,0"
+       style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.83465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       transform="matrix(0.35277776,0,0,-0.35277776,106.67115,6.5899251)"
+       clip-path="url(#clipPath1374-3)" />
+  </g>
+</svg>

--- a/public/piece/Hidden/1_Black.svg
+++ b/public/piece/Hidden/1_Black.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="30mm"
+   height="34mm"
+   viewBox="0 0 30 34"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1374-3-6">
+      <path
+         d="M 0,2834.646 H 2834.646 V 0 H 0 Z"
+         transform="translate(-461.11531,-1475.1781)"
+         id="path1374-2-9" />
+    </clipPath>
+  </defs>
+  <g
+     id="layer1"
+     transform="translate(-204)">
+    <path
+       id="path8"
+       d="m 0,0 -21.223,7.255 c -0.337,0.115 -0.707,0.115 -1.044,0 L -43.49,0 c -0.512,-0.175 -0.879,-0.592 -0.956,-1.088 L -54.328,-64.8 c -0.128,-0.823 0.569,-1.559 1.477,-1.559 h 31.106 31.106 c 0.907,0 1.605,0.736 1.477,1.559 L 0.955,-1.088 C 0.879,-0.592 0.512,-0.175 0,0"
+       style="font-variation-settings:normal;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.83465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       transform="matrix(-0.35277776,0,0,0.35277776,211.32884,27.410075)"
+       clip-path="url(#clipPath1374-3-6)" />
+  </g>
+</svg>

--- a/public/piece/Hidden/1_Blank.svg
+++ b/public/piece/Hidden/1_Blank.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="30mm"
+   height="34mm"
+   viewBox="0 0 30 34"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1374-3-9">
+      <path
+         d="M 0,2834.646 H 2834.646 V 0 H 0 Z"
+         transform="translate(-461.11531,-1475.1781)"
+         id="path1374-2-4" />
+    </clipPath>
+  </defs>
+  <g
+     id="layer1"
+     transform="translate(-284)">
+    <path
+       id="path9"
+       d="m 0,0 -21.223,7.255 c -0.337,0.115 -0.707,0.115 -1.044,0 L -43.49,0 c -0.512,-0.175 -0.879,-0.592 -0.956,-1.088 L -54.328,-64.8 c -0.128,-0.823 0.569,-1.559 1.477,-1.559 h 31.106 31.106 c 0.907,0 1.605,0.736 1.477,1.559 L 0.955,-1.088 C 0.879,-0.592 0.512,-0.175 0,0"
+       style="font-variation-settings:normal;fill:#ffc873;fill-opacity:1;fill-rule:nonzero;stroke:#4d3d23;stroke-width:2.83465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       transform="matrix(-0.35277776,0,0,0.35277776,291.32884,27.410075)"
+       clip-path="url(#clipPath1374-3-9)" />
+  </g>
+</svg>

--- a/public/piece/Hidden/1_White.svg
+++ b/public/piece/Hidden/1_White.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="30mm"
+   height="34mm"
+   viewBox="0 0 30 34"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1374-3">
+      <path
+         d="M 0,2834.646 H 2834.646 V 0 H 0 Z"
+         transform="translate(-461.11531,-1475.1781)"
+         id="path1374-2" />
+    </clipPath>
+  </defs>
+  <g
+     id="layer1"
+     transform="translate(-124)">
+    <path
+       id="path7"
+       d="m 0,0 -21.223,7.255 c -0.337,0.115 -0.707,0.115 -1.044,0 L -43.49,0 c -0.512,-0.175 -0.879,-0.592 -0.956,-1.088 L -54.328,-64.8 c -0.128,-0.823 0.569,-1.559 1.477,-1.559 h 31.106 31.106 c 0.907,0 1.605,0.736 1.477,1.559 L 0.955,-1.088 C 0.879,-0.592 0.512,-0.175 0,0"
+       style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.83465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       transform="matrix(-0.35277776,0,0,0.35277776,131.32884,27.410075)"
+       clip-path="url(#clipPath1374-3)" />
+  </g>
+</svg>

--- a/public/piece/Hidden/Invisible_Shogi.svg
+++ b/public/piece/Hidden/Invisible_Shogi.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="30mm"
+   height="34mm"
+   viewBox="0 0 30 34"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="Invisible_Shogi.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="2.6414236"
+     inkscape:cx="33.126076"
+     inkscape:cy="77.798956"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1674">
+      <path
+         d="M 0,2834.646 H 2834.646 V 0 H 0 Z"
+         transform="translate(-1170.7737,-1476.2824)"
+         id="path1674" />
+    </clipPath>
+  </defs>
+  <g
+     id="layer1">
+    <path
+       id="path5321"
+       d="m 0,0 -22.28,7.578 c -0.3,0.102 -0.625,0.102 -0.924,0 L -45.484,0 c -0.502,-0.171 -0.868,-0.604 -0.949,-1.125 l -10.308,-66.12 c -0.134,-0.86 0.535,-1.636 1.411,-1.636 h 32.588 32.588 c 0.875,0 1.545,0.776 1.41,1.636 L 0.948,-1.125 C 0.867,-0.604 0.502,-0.171 0,0"
+       style="font-variation-settings:normal;fill:#ffffff;fill-opacity:0.501961;fill-rule:nonzero;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       transform="matrix(0.33219911,0,0,-0.33709845,22.555042,6.6803862)"
+       clip-path="url(#clipPath1674)" />
+    <path
+       style="font-size:20.9672px;line-height:0.9;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.599996;stroke-miterlimit:10"
+       d="m 13.654912,22.180101 h 2.078292 v 2.600424 h -2.078292 z m 2.016864,-1.50497 h -1.955437 v -1.576635 q 0,-1.034027 0.286661,-1.69949 0.286661,-0.665463 1.208071,-1.545921 l 0.921411,-0.911172 q 0.583559,-0.542609 0.839507,-1.023789 0.266185,-0.481181 0.266185,-0.982838 0,-0.911172 -0.675701,-1.474256 -0.665463,-0.563084 -1.771155,-0.563084 -0.808793,0 -1.730204,0.358326 -0.911172,0.358326 -1.904247,1.044265 v -1.924723 q 0.962362,-0.5835602 1.945199,-0.8702211 0.993075,-0.2866609 2.047578,-0.2866609 1.883772,0 3.020178,0.993075 1.146643,0.993076 1.146643,2.6209 0,0.77808 -0.368564,1.484494 -0.368564,0.696177 -1.289974,1.576635 l -0.900934,0.880459 q -0.481181,0.481181 -0.685939,0.757604 -0.19452,0.266185 -0.276423,0.522132 -0.06143,0.214996 -0.09214,0.522133 -0.03071,0.307136 -0.03071,0.839507 z"
+       id="text5319"
+       aria-label="?" />
+    <path
+       id="path5320"
+       d="m 0,0 -22.28,7.578 c -0.3,0.102 -0.625,0.102 -0.924,0 L -45.484,0 c -0.502,-0.171 -0.868,-0.604 -0.949,-1.125 l -10.308,-66.12 c -0.134,-0.86 0.535,-1.636 1.411,-1.636 h 32.588 32.588 c 0.875,0 1.545,0.776 1.41,1.636 L 0.948,-1.125 C 0.867,-0.604 0.502,-0.171 0,0"
+       style="font-variation-settings:normal;fill:none;fill-opacity:0.501961;fill-rule:nonzero;stroke:#000000;stroke-width:3.40157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:6.80315, 3.40157;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       transform="matrix(0.35277776,0,0,-0.35277776,23.02301,6.2003262)"
+       clip-path="url(#clipPath1674)" />
+  </g>
+</svg>


### PR DESCRIPTION
For players who want a visibility challenge, they should have the option to use blank pieces (You can choose whether to include tan or BnW pieces) and invisible pieces. (What I sent is simply the icon for the piece menu.)