### PR TITLE
Define first player for #708 and for #738

### DIFF
--- a/modules/game/src/main/Game.scala
+++ b/modules/game/src/main/Game.scala
@@ -66,7 +66,9 @@ case class Game(
 
   def opponent(c: Color): Player = player(!c)
 
-  lazy val firstColor = Color.fromSente(sentePlayer before gotePlayer)
+  // View handicap games from the handicap receiver's perspective
+  // View other games from the dominant (title/rating) player's perspective
+  lazy val firstColor = if (isHandicap) !startColor else Color.fromSente(sentePlayer before gotePlayer)
   def firstPlayer     = player(firstColor)
   def secondPlayer    = player(!firstColor)
 

--- a/modules/tournament/src/main/AutoPairing.scala
+++ b/modules/tournament/src/main/AutoPairing.scala
@@ -52,7 +52,7 @@ final class AutoPairing(
   }
 
   private def makePlayer(color: Color, player: Player) =
-    GamePlayer.make(color, player.userId, player.rating, provisional = player.provisional, isBot = false)
+    GamePlayer.make(color, player.userId, player.rating, provisional = player.provisional, isBot = false, hasTitle = false)
 
   private def usernameOf(userId: User.ID) =
     lightUserApi.sync(userId).fold(userId)(_.name)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"   % "2.9.4")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("ch.epfl.scala"     % "sbt-bloop"    % "1.6.0")
 // addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.0.7")


### PR DESCRIPTION
First player has at least two meanings:
- Which player has the greater reputation? (ou / gyoku)
- From which perspective do we wish to view a game?

This PR does not modify art assets, but does change the "Player before" definition to consider:
- Humans have a greater reputation than engines
- Titled players have a greater reputation than non-titled players

Although Lichess TV prefers to display games from the perspective of the higher-rated player, for Lishogi TV we should prefer to view a game from:
- Handicap games: handicap receiver perspective
- Human perspective (or if BOT versus AI, BOT perspective)
- Higher-rated player perspective