### PR TITLE
Fixes #1011

### DIFF
--- a/ui/embed/src/analyse/ctrl.ts
+++ b/ui/embed/src/analyse/ctrl.ts
@@ -21,6 +21,12 @@ export class AnalyseCtrl {
     this.tree = makeTree(treeOps.reconstruct(this.data.treeParts));
     this.initialPath = treePath.root;
 
+    const hashPly = Number.parseInt(location.hash.slice(1), 10);
+    if (hashPly) {
+      const mainline = treeOps.mainlineNodeList(this.tree.root);
+      this.initialPath = treeOps.takePathWhile(mainline, n => n.ply <= hashPly);
+    }
+
     this.jump(this.initialPath);
 
     this.initNotation();


### PR DESCRIPTION
## Problem
Study embeds with a  hash in the URL (e.g. )
always displayed move 0 instead of jumping to the specified move.

## Cause
The embed has its own minimal  in
which always initialized to  without reading .

## Fix
Parse the URL hash in the embed controller constructor and jump to the corresponding ply if present.